### PR TITLE
fix(coverage): use idxmap for ordered coverage map merge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,9 @@ dependencies = [
 [[package]]
 name = "istanbul-oxi-coverage"
 version = "0.1.0"
+dependencies = [
+ "indexmap",
+]
 
 [[package]]
 name = "istanbul-oxi-instrument"

--- a/packages/istanbul-oxi-coverage/Cargo.toml
+++ b/packages/istanbul-oxi-coverage/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+indexmap = "1.8.0"

--- a/packages/istanbul-oxi-coverage/src/coverage_summary.rs
+++ b/packages/istanbul-oxi-coverage/src/coverage_summary.rs
@@ -42,11 +42,11 @@ impl Totals {
 
 #[derive(Default, Copy, Clone)]
 pub struct CoverageSummary {
-    lines: Totals,
-    statements: Totals,
-    functions: Totals,
-    branches: Totals,
-    branches_true: Option<Totals>,
+    pub(crate) lines: Totals,
+    pub(crate) statements: Totals,
+    pub(crate) functions: Totals,
+    pub(crate) branches: Totals,
+    pub(crate) branches_true: Option<Totals>,
 }
 
 impl CoverageSummary {

--- a/packages/istanbul-oxi-coverage/src/range.rs
+++ b/packages/istanbul-oxi-coverage/src/range.rs
@@ -1,16 +1,27 @@
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default, Debug)]
 pub struct Location {
     pub(crate) line: u32,
     pub(crate) column: u32,
 }
+impl Location {
+    pub fn default() -> Location {
+        Location { line: 0, column: 0 }
+    }
+}
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default, Debug)]
 pub struct Range {
     pub(crate) start: Location,
     pub(crate) end: Location,
 }
 
 impl Range {
+    pub fn default() -> Range {
+        Range {
+            start: Default::default(),
+            end: Default::default(),
+        }
+    }
     pub fn new(start_line: u32, start_column: u32, end_line: u32, end_column: u32) -> Range {
         Range {
             start: Location {

--- a/packages/istanbul-oxi-coverage/src/types.rs
+++ b/packages/istanbul-oxi-coverage/src/types.rs
@@ -1,17 +1,17 @@
-use std::collections::HashMap;
+use indexmap::IndexMap;
 
 use crate::{coverage::Coverage, Range};
 
-#[derive(Clone)]
-pub struct FunctionMapping {
+#[derive(Clone, Debug)]
+pub struct Function {
     pub(crate) name: String,
     pub(crate) decl: Range,
     pub(crate) loc: Range,
     pub(crate) line: u32,
 }
 
-#[derive(Clone)]
-pub struct BranchMapping {
+#[derive(Clone, Debug)]
+pub struct Branch {
     pub(crate) loc: Range,
     pub(crate) branch_type: String,
     pub(crate) locations: Vec<Range>,
@@ -19,9 +19,9 @@ pub struct BranchMapping {
 }
 
 /// Map to line number to hit count.
-pub type LineHitMap = HashMap<u32, u32>;
-pub type StatementMap = HashMap<u32, Range>;
-pub type FunctionMap = HashMap<u32, FunctionMapping>;
-pub type BranchMap = HashMap<u32, BranchMapping>;
-pub type BranchHitMap = HashMap<u32, Vec<u32>>;
-pub type BranchCoverageMap = HashMap<u32, Coverage>;
+pub type LineHitMap = IndexMap<u32, u32>;
+pub type StatementMap = IndexMap<u32, Range>;
+pub type FunctionMap = IndexMap<u32, Function>;
+pub type BranchMap = IndexMap<u32, Branch>;
+pub type BranchHitMap = IndexMap<u32, Vec<u32>>;
+pub type BranchCoverageMap = IndexMap<u32, Coverage>;


### PR DESCRIPTION
Using HashMap, or BTreeMap doesn't gaurantee specific order of the coverage data while merging 2 different coverage. This is due to original implementation relies on implicit ordered behavior of JS Object's key indexer. Using IndexMap instead to mimic similar behavior.
