### PR TITLE
[BOT] build(cargo): upgrade dependencies for swc_core

### DIFF
--- a/packages/swc-coverage-instrument/Cargo.toml
+++ b/packages/swc-coverage-instrument/Cargo.toml
@@ -14,7 +14,7 @@ regex          = "1.7.0"
 serde          = { version = "1.0.147", features = ["derive"] }
 serde_json     = "1.0.87"
 
-swc_core = { version = "0.43.2", features = [
+swc_core = { version = "0.48.2", features = [
   "common",
   "ecma_quote",
   "ecma_visit",

--- a/packages/swc-plugin-coverage/Cargo.toml
+++ b/packages/swc-plugin-coverage/Cargo.toml
@@ -13,6 +13,6 @@ crate-type = ["cdylib"]
 [dependencies]
 serde_json              = "1.0.87"
 swc-coverage-instrument = { version = "0.0.14", path = "../swc-coverage-instrument" }
-swc_core                = { version = "0.43.2", features = ["plugin_transform"] }
+swc_core                = { version = "0.48.2", features = ["plugin_transform"] }
 tracing                 = "0.1.37"
 tracing-subscriber      = { version = "0.3.16", features = ["fmt"] }


### PR DESCRIPTION
Hello! This is a friendly bot trying to update some of the dependencies in this repository.

  This PR is result of running bots for you.
  If there are new updates, this PR will try to replace existing commit with new ones.
  Unfortunately it cannot resolve conflicts, or resolve breaking changes automatically.
  If it happens, please try to resolve it manually.

  You can add new commits on top of this PR to do so. Then bot will not try to update PR and let you resolve it.

  

  It Looks like there were some errors while trying to upgrade dependencies. Please check below error message:

  ```
      Updating crates.io index
error: failed to select a version for `swc_core`.
    ... required by package `swc-plugin-coverage v0.0.14 (/home/runner/work/swc-plugin-coverage-instrument/swc-plugin-coverage-instrument/packages/swc-plugin-coverage)`
versions that meet the requirements `^0.48.2` are: 0.48.2

the package `swc-plugin-coverage` depends on `swc_core`, with features: `plugin_transform` but `swc_core` does not have these features.


failed to select a version for `swc_core` which could resolve this conflict

  ```
  