### PR TITLE
feat(visitor): let ObjectMethods without Function Ident can be covere…

### DIFF
--- a/packages/swc-coverage-instrument/src/macros/instrumentation_visitor.rs
+++ b/packages/swc-coverage-instrument/src/macros/instrumentation_visitor.rs
@@ -341,6 +341,13 @@ macro_rules! instrumentation_visitor {
                             );
                             method_prop.visit_mut_children_with(self);
                         }
+                    } else {
+                        let ident = Ident {
+                            sym: "anonymous".into(),
+                            ..Ident::dummy()
+                        };
+                        self.create_fn_instrumentation(&Some(&ident), &mut method_prop.function);
+                        method_prop.visit_mut_children_with(self);
                     }
                 }
             }
@@ -356,6 +363,7 @@ macro_rules! instrumentation_visitor {
                 _ => {
                     // TODO: this does not cover all of PropName enum yet
                     // TODO: duplicated logic between class_method
+                    println!("getter_prop: {:?}", getter_prop);
                     if let PropName::Ident(ident) = &getter_prop.key {
                         let should_ignore_via_options = self
                             .instrument_options
@@ -395,6 +403,37 @@ macro_rules! instrumentation_visitor {
                             }
                             getter_prop.visit_mut_children_with(self);
                         }
+                    } else {
+                        let span = &getter_prop.span;
+                        let name: Option<String> = Some("anonymous".to_owned());
+
+                        let range =
+                            crate::lookup_range::get_range_from_span(&self.source_map, span);
+                        if let Some(body) = &mut getter_prop.body {
+                            let body_span = body.span;
+                            let body_range = crate::lookup_range::get_range_from_span(
+                                &self.source_map,
+                                &body_span,
+                            );
+                            let index =
+                                self.cov
+                                    .borrow_mut()
+                                    .new_function(&name, &range, &body_range);
+
+                            let b = crate::create_increase_counter_expr(
+                                &crate::constants::idents::IDENT_F,
+                                index,
+                                &self.cov_fn_ident,
+                                None,
+                            );
+                            let mut prepended_vec = vec![Stmt::Expr(ExprStmt {
+                                span: swc_core::common::DUMMY_SP,
+                                expr: Box::new(b),
+                            })];
+                            prepended_vec.extend(body.stmts.take());
+                            body.stmts = prepended_vec;
+                        }
+                        getter_prop.visit_mut_children_with(self);
                     }
                 }
             }
@@ -450,6 +489,37 @@ macro_rules! instrumentation_visitor {
                             }
                             setter_prop.visit_mut_children_with(self);
                         }
+                    } else {
+                        let span = &setter_prop.span;
+                        let name: Option<String> = Some("anonymous".to_owned());
+
+                        let range =
+                            crate::lookup_range::get_range_from_span(&self.source_map, span);
+                        if let Some(body) = &mut setter_prop.body {
+                            let body_span = body.span;
+                            let body_range = crate::lookup_range::get_range_from_span(
+                                &self.source_map,
+                                &body_span,
+                            );
+                            let index =
+                                self.cov
+                                    .borrow_mut()
+                                    .new_function(&name, &range, &body_range);
+
+                            let b = crate::create_increase_counter_expr(
+                                &crate::constants::idents::IDENT_F,
+                                index,
+                                &self.cov_fn_ident,
+                                None,
+                            );
+                            let mut prepended_vec = vec![Stmt::Expr(ExprStmt {
+                                span: swc_core::common::DUMMY_SP,
+                                expr: Box::new(b),
+                            })];
+                            prepended_vec.extend(body.stmts.take());
+                            body.stmts = prepended_vec;
+                        }
+                        setter_prop.visit_mut_children_with(self);
                     }
                 }
             }

--- a/packages/swc-coverage-instrument/src/macros/instrumentation_visitor.rs
+++ b/packages/swc-coverage-instrument/src/macros/instrumentation_visitor.rs
@@ -363,7 +363,6 @@ macro_rules! instrumentation_visitor {
                 _ => {
                     // TODO: this does not cover all of PropName enum yet
                     // TODO: duplicated logic between class_method
-                    println!("getter_prop: {:?}", getter_prop);
                     if let PropName::Ident(ident) = &getter_prop.key {
                         let should_ignore_via_options = self
                             .instrument_options

--- a/spec/fixtures/functions.yaml
+++ b/spec/fixtures/functions.yaml
@@ -144,3 +144,41 @@ tests:
     lines: {'2': 1, '4': 1}
     functions: {'0': 1}
     statements: {'0': 1, '1': 1}
+---
+name: functions declared in an object
+code: |
+  const computedIdx = 'computed';
+  const obj = {
+    normal() {
+      console.log('normal');
+    },
+    'string'() {
+      console.log('string literal');
+    },
+    1() {
+      console.log('number literal');
+    },
+    2n() {
+      console.log('bigint literal');
+    },
+    [computedIdx]() {
+      console.log('computed property');
+    },
+    get getterFn() {
+      console.log('getter function');
+    },
+    set setterFn(val) {
+      console.log('setter function', val);
+    },
+    get 'getterFn'() {
+      console.log('getter function with string literal');
+    },
+    set 'setterStringLiteral'(val) {
+      console.log('setter function with string literal', val);
+    },
+  };
+tests:
+  - name: all functions in object are covered
+    lines: {'1': 1, '2': 1, '4': 0, '7': 0, '10': 0, '13': 0, '16': 0, '19': 0, '22': 0, '25': 0, '28': 0}
+    functions: {'0': 0, '1': 0, '2': 0, '3': 0, '4': 0, '5': 0, '6': 0, '7': 0, '8': 0}
+    statements: {'0': 1, '1': 1, '2': 0, '3': 0, '4': 0, '5': 0, '6': 0, '7': 0, '8': 0, '9': 0, '10': 0}


### PR DESCRIPTION
As some methods in object can not be covered, update instrument_visitors to cover cases as follow.
```javascript
  const computedIdx = 'computed';
  const obj = {
    normal() {
      console.log('normal');
    },
    'string'() {
      console.log('string literal');
    },
    1() {
      console.log('number literal');
    },
    2n() {
      console.log('bigint literal');
    },
    [computedIdx]() {
      console.log('computed property');
    },
    get getterFn() {
      console.log('getter function');
    },
    set setterFn(val) {
      console.log('setter function', val);
    },
    get 'getterFn'() {
      console.log('getter function with string literal');
    },
    set 'setterStringLiteral'(val) {
      console.log('setter function with string literal', val);
    },
  };
```
