### PR TITLE
fix(visitor): add stmt counter for export const

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "istanbul-oxide"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "indexmap",
  "serde",
@@ -1443,7 +1443,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "swc-coverage-instrument"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "istanbul-oxide",
  "once_cell",
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "swc-plugin-coverage"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "serde_json",
  "swc-coverage-instrument",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 #lto = true
 
   [workspace.dependencies]
-  istanbul-oxide          = { path = "./packages/istanbul-oxide", version = "0.0.30" }
+  istanbul-oxide          = { path = "./packages/istanbul-oxide", version = "0.0.31" }
   swc-coverage-instrument = { path = "./packages/swc-coverage-instrument" }
 
   getrandom          = { version = "0.2.15" }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "swc-plugin-coverage-instrument",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "swc-plugin-coverage-instrument",
-      "version": "0.0.30",
+      "version": "0.0.31",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swc-plugin-coverage-instrument",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "description": "SWC coverage instrumentation plugin",
   "main": "./target/wasm32-wasip1/release/swc_plugin_coverage.wasm",
   "napi": {

--- a/packages/istanbul-oxide/Cargo.toml
+++ b/packages/istanbul-oxide/Cargo.toml
@@ -5,7 +5,7 @@ edition     = "2021"
 license     = "MIT"
 name        = "istanbul-oxide"
 repository  = "https://github.com/kwonoj/swc-coverage-instrument"
-version     = "0.0.30"
+version     = "0.0.31"
 
 [dependencies]
 indexmap = { workspace = true, features = ["serde"] }

--- a/packages/swc-coverage-instrument/Cargo.toml
+++ b/packages/swc-coverage-instrument/Cargo.toml
@@ -5,7 +5,7 @@ edition     = "2021"
 license     = "MIT"
 name        = "swc-coverage-instrument"
 repository  = "https://github.com/kwonoj/swc-coverage-instrument"
-version     = "0.0.30"
+version     = "0.0.31"
 
 [dependencies]
 istanbul-oxide = { workspace = true }

--- a/packages/swc-plugin-coverage/Cargo.toml
+++ b/packages/swc-plugin-coverage/Cargo.toml
@@ -5,7 +5,7 @@ edition     = "2021"
 license     = "MIT"
 name        = "swc-plugin-coverage"
 repository  = "https://github.com/kwonoj/swc-coverage-instrument"
-version     = "0.0.30"
+version     = "0.0.31"
 
 [lib]
 crate-type = ["cdylib"]

--- a/spec/fixtures/issue-277.yaml
+++ b/spec/fixtures/issue-277.yaml
@@ -1,0 +1,13 @@
+---
+name: export const statements coverage (issue 277)
+code: |
+  export const sayHi = () => 'hi';
+
+  export const sayHii = () => 'hii';
+instrumentOpts:
+  esModules: true
+tests:
+  - name: export const coverage
+    lines: {'1': 1, '3': 1}
+    statements: {'0': 1, '1': 0, '2': 1, '3': 0}
+    functions: {'0': 0, '1': 0}

--- a/spec/swc-coverage-custom-transform/Cargo.lock
+++ b/spec/swc-coverage-custom-transform/Cargo.lock
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "istanbul-oxide"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "indexmap",
  "serde",
@@ -1656,7 +1656,7 @@ dependencies = [
 
 [[package]]
 name = "swc-coverage-instrument"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "istanbul-oxide",
  "once_cell",

--- a/spec/swc-coverage-custom-transform/Cargo.lock
+++ b/spec/swc-coverage-custom-transform/Cargo.lock
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "istanbul-oxide"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "indexmap",
  "serde",
@@ -1656,7 +1656,7 @@ dependencies = [
 
 [[package]]
 name = "swc-coverage-instrument"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "istanbul-oxide",
  "once_cell",

--- a/spec/swc-coverage-custom-transform/Cargo.toml
+++ b/spec/swc-coverage-custom-transform/Cargo.toml
@@ -21,7 +21,7 @@ napi-derive = { version = "2.12.3", default-features = false, features = [
 ] }
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = { version = "1.0.120", features = ["unbounded_depth"] }
-swc-coverage-instrument = { version = "0.0.30", path = "../../packages/swc-coverage-instrument" }
+swc-coverage-instrument = { version = "0.0.31", path = "../../packages/swc-coverage-instrument" }
 swc_core = { version = "31.1.0", features = [
   "common_concurrent",
   "ecma_transforms",

--- a/spec/util/verifier.ts
+++ b/spec/util/verifier.ts
@@ -271,7 +271,10 @@ const create = (code, options = {}, instrumentOptions = {}, inputSourceMap) => {
     );
   }
   if (!(verror || generateOnly)) {
-    wrapped = "{ var output;\n" + instrumenterOutput + "\nreturn output;\n}";
+    wrapped =
+      "{ var exports={};\n var output;\n" +
+      instrumenterOutput +
+      "\nreturn output;\n}";
     g[coverageVariable] = undefined;
     try {
       if (options.isAsync) {


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
