### PR TITLE
feat: add coverageGlobalScope / coverageGlobalScopeFunc options (CSP-safe global lookup)

### DIFF
--- a/packages/swc-coverage-instrument/src/coverage_template/create_global_stmt_template.rs
+++ b/packages/swc-coverage-instrument/src/coverage_template/create_global_stmt_template.rs
@@ -38,3 +38,20 @@ pub fn create_global_stmt_template(coverage_global_scope: &str) -> Stmt {
         }),
     )
 }
+
+/// Creates an assignment statement that emits the coverage global scope expression
+/// verbatim, with no `Function` constructor: `var global = <coverage_global_scope>;`.
+/// This is the CSP-safe counterpart to `create_global_stmt_template`, mirroring
+/// babel-plugin-istanbul's `globalTemplateVariable` (used when `coverageGlobalScopeFunc`
+/// is false). Some Content Security Policies forbid the `Function` constructor even when
+/// reached through a prototype, so callers can pass e.g. an inline
+/// `globalThis`/`self`/`window`/`global` lookup expression here instead.
+/// See https://github.com/istanbuljs/babel-plugin-istanbul/issues/212
+///
+/// The scope string is printed verbatim via `quote_ident!`, the same mechanism the
+/// Function-constructor template above relies on to smuggle `((function(){}).constructor)`
+/// through as source text.
+pub fn create_global_var_stmt_template(coverage_global_scope: &str) -> Stmt {
+    let scope_expr = quote_ident!(Default::default(), coverage_global_scope);
+    create_assignment_stmt(&IDENT_GLOBAL, Expr::Ident(scope_expr))
+}

--- a/packages/swc-coverage-instrument/src/lib.rs
+++ b/packages/swc-coverage-instrument/src/lib.rs
@@ -12,6 +12,7 @@ use coverage_template::create_assignment_stmt::create_assignment_stmt;
 use coverage_template::create_coverage_data_object::create_coverage_data_object;
 use coverage_template::create_coverage_fn_decl::*;
 use coverage_template::create_global_stmt_template::create_global_stmt_template;
+use coverage_template::create_global_stmt_template::create_global_var_stmt_template;
 use source_coverage::SourceCoverage;
 
 #[macro_use]

--- a/packages/swc-coverage-instrument/src/options/instrument_options.rs
+++ b/packages/swc-coverage-instrument/src/options/instrument_options.rs
@@ -31,6 +31,18 @@ pub struct InstrumentOptions {
     // This option accepts an array of wax(https://crates.io/crates/wax)-compatible glob patterns
     // and will match against the filename provided by swc's core.
     pub unstable_exclude: Option<Vec<String>>,
+    // The expression used to locate the global scope object where coverage
+    // counters are stored. Mirrors babel-plugin-istanbul's `coverageGlobalScope`
+    // (default `"this"`). When `coverage_global_scope_func` is false, this string
+    // is emitted verbatim as the initializer (e.g. an inline
+    // `globalThis`/`self`/`window`/`global` lookup) instead of being wrapped in a
+    // `Function` constructor, which some Content Security Policies forbid.
+    // See https://github.com/istanbuljs/babel-plugin-istanbul/issues/212
+    pub coverage_global_scope: String,
+    // When true (default, matching istanbul), the global scope is located via an
+    // evaluated `Function` constructor. Set to false to emit `coverage_global_scope`
+    // directly and avoid the eval-like construct.
+    pub coverage_global_scope_func: bool,
 }
 
 impl Default for InstrumentOptions {
@@ -44,6 +56,8 @@ impl Default for InstrumentOptions {
             instrument_log: Default::default(),
             debug_initial_coverage_comment: false,
             unstable_exclude: Default::default(),
+            coverage_global_scope: "this".to_string(),
+            coverage_global_scope_func: true,
         }
     }
 }

--- a/packages/swc-coverage-instrument/src/visitors/coverage_visitor.rs
+++ b/packages/swc-coverage-instrument/src/visitors/coverage_visitor.rs
@@ -54,10 +54,13 @@ impl<C: Clone + Comments, S: SourceMapper> CoverageVisitor<C, S> {
     fn get_coverage_templates(&mut self) -> (Stmt, Stmt) {
         self.cov.borrow_mut().freeze();
 
-        //TODO: option: global coverage variable scope. (optional, default `this`)
-        let coverage_global_scope = "this";
-        //TODO: option: use an evaluated function to find coverageGlobalScope.
-        let coverage_global_scope_func = true;
+        // Global coverage variable scope (optional, default `this`), mirroring
+        // babel-plugin-istanbul's `coverageGlobalScope`.
+        let coverage_global_scope = self.instrument_options.coverage_global_scope.as_str();
+        // Whether to locate coverageGlobalScope via an evaluated Function constructor
+        // (default true, matching istanbul). When false, emit the scope expression
+        // directly to avoid the eval-like construct some CSPs forbid.
+        let coverage_global_scope_func = self.instrument_options.coverage_global_scope_func;
 
         let gv_template = if coverage_global_scope_func {
             // TODO: path.scope.getBinding('Function')
@@ -76,12 +79,9 @@ impl<C: Clone + Comments, S: SourceMapper> CoverageVisitor<C, S> {
                 crate::create_global_stmt_template(coverage_global_scope)
             }
         } else {
-            unimplemented!("");
-            /*
-            gvTemplate = globalTemplateVariable({
-                GLOBAL_COVERAGE_SCOPE: opts.coverageGlobalScope
-            });
-            */
+            // globalTemplateVariable: `var global = <coverageGlobalScope>;`
+            // Emits the scope expression verbatim, with no Function constructor.
+            crate::create_global_var_stmt_template(coverage_global_scope)
         };
 
         let coverage_template = crate::create_coverage_fn_decl(

--- a/spec/plugin.spec.ts
+++ b/spec/plugin.spec.ts
@@ -9,6 +9,37 @@ instrumentSync(`console.log('boo')`, "anon");
 const tryDescribe = process.env.SWC_TRANSFORM_CUSTOM ? describe.skip : describe;
 
 tryDescribe("Plugin options", () => {
+  it("should emit the CSP-safe global scope verbatim when coverageGlobalScopeFunc is false", () => {
+    // https://github.com/istanbuljs/babel-plugin-istanbul/issues/212
+    const scope =
+      '(function(){var g;if(typeof globalThis!=="undefined"){g=globalThis}else{g=this}return g})()';
+
+    const output = instrumentSync(`console.log('hello');`, "csp-scope.js", undefined, {
+      coverageGlobalScopeFunc: false,
+      coverageGlobalScope: scope,
+    });
+
+    assert.include(
+      output.code,
+      `var global = ${scope}`,
+      "expected the scope expression emitted verbatim",
+    );
+    assert.notInclude(
+      output.code,
+      `((function(){}).constructor)("return`,
+      "expected NO Function-constructor preamble",
+    );
+  });
+
+  it("should keep the Function-constructor scope by default (istanbul parity)", () => {
+    const output = instrumentSync(`console.log('hello');`, "default-scope.js");
+    assert.include(
+      output.code,
+      `((function(){}).constructor)("return this")()`,
+      "default behavior should be unchanged",
+    );
+  });
+
   it("should able to exclude", () => {
     const code = `console.log('hello');`;
 


### PR DESCRIPTION
## What

Implements the two `TODO:` markers in `coverage_visitor.rs` (`get_coverage_templates`) by adding two options that mirror babel-plugin-istanbul / istanbul-lib-instrument:

- `coverageGlobalScope: string` (default `"this"`) — the expression used to locate the global scope object that holds the coverage counters.
- `coverageGlobalScopeFunc: boolean` (default `true`) — when `true` (the default, unchanged behavior), the scope is located via the evaluated Function-constructor template. When `false`, the scope expression is emitted verbatim: `var global = <coverageGlobalScope>;`.

## Why

The current hardcoded template emits `var global = new ((function(){}).constructor)("return this")();`. Reaching the `Function` constructor through a prototype is still an eval-like construct, so pages served with a Content-Security-Policy that lacks `'unsafe-eval'` refuse to run instrumented bundles.

This is the same problem istanbul itself hit — istanbuljs/babel-plugin-istanbul#212 was resolved by adding these exact two options, and this PR brings the plugin to parity so CSP-restricted apps can pass e.g. an inline `globalThis`/`self`/`window`/`global` lookup instead.

## Changes

- `options/instrument_options.rs`: two new fields on `InstrumentOptions` with istanbul-matching defaults. The struct already uses `#[serde(rename_all = "camelCase", default)]`, so the JS-side option names match babel-plugin-istanbul exactly and existing configs are unaffected.
- `visitors/coverage_visitor.rs`: read both values from `instrument_options` instead of the hardcoded `"this"` / `true`; implement the previously-`unimplemented!()` else branch (babel's `globalTemplateVariable`).
- `coverage_template/create_global_stmt_template.rs`: new `create_global_var_stmt_template()` emitting the scope expression verbatim, using the same `quote_ident!` verbatim-printing mechanism the existing Function-constructor template relies on.
- `spec/plugin.spec.ts`: two tests — `coverageGlobalScopeFunc: false` emits the scope verbatim with no Function constructor; defaults still emit the Function-constructor template (behavior unchanged).

Note: babel's third template (`globalTemplateAlteredFunction`, used when a local `Function` binding shadows the global one) is intentionally not implemented — the repo already documents scope-binding detection as unsupported (`create_global_stmt_template.rs` comment), and that branch remains `unimplemented!()` behind the existing `is_function_binding_scope = false`.

## Compatibility

Defaults reproduce today's output byte-for-byte; both options are opt-in. Serde `default` on the struct means configs without the new keys deserialize exactly as before.